### PR TITLE
small doc fixes: RBAC support + pluralize 'secrets'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ spec:
         - image: gcr.io/larson-deployment/gke-ci:0.1
           env:
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
-              value: "/var/run/secret/cloud.google.com/file-with-secrets.json"
+              value: "/var/run/secrets/cloud.google.com/file-with-secrets.json"
           volumeMounts:
             - name: "service-account"
-              mountPath: "/var/run/secret/cloud.google.com"
+              mountPath: "/var/run/secrets/cloud.google.com"
           imagePullPolicy: Always
           name: gke-ci
           command: ["/usr/bin/python"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ and do some setup on Google to create resources:
 
 3. Create a PubSub Subscriber for the `cloud_builds` topic, name it `gke_ci`.
 
+4. If your cluster has
+    [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
+    enabled, you need to enable access to the Kubernetes API for the
+    pod.  This can be done by creating a new service account:
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gke-ci
+```
+
+And then giving it permission to edit deployments:
+
+        kubectl create clusterrolebinding gke-ci-admin \
+          --clusterrole=cluster-admin \
+          --serviceaccount=default:gke-ci \
+          --namespace=default
+
 Finally, create your `deployment.yaml`:
 
 ```
@@ -86,6 +105,7 @@ spec:
         - name: "service-account"
           secret:
             secretName: gke-ci
+      serviceAccountName: gke-ci # if RBAC is enabled
 ```
 
 Then provision it via:


### PR DESCRIPTION
I figured I would bundle these together.  The first is a silly
normalization -- Kubernetes uses `/var/run/secrets` (plural), so do
the same in the deployment you have.

Second is adding support for RBAC-enabled clusters, which I think is
the default for new clusters on GKE.  There might be a way to do this
with less permissions than 'cluster-admin', but I didn't look deeply
into it.