### PR TITLE
build: use 2 stage Dockerfile for minimally-sized image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM ubuntu:zesty
+FROM python:2-alpine3.7 as builder
 
-RUN apt-get update
-RUN apt-get install python-dev -y
-RUN apt-get install python-pip -y
-COPY . /
-RUN pip install -r requirements.txt
-RUN pip install --upgrade ply
+RUN apk add --update \
+    python \
+    python-dev \
+    py-pip \
+    build-base \
+  && rm -rf /var/cache/apk/*
+RUN pip install virtualenv
+
+WORKDIR /srv
+COPY . /srv
+RUN virtualenv env
+RUN env/bin/pip install -r requirements.txt
+RUN env/bin/pip install --upgrade ply
+
+FROM python:2-alpine3.7
+COPY --from=builder \
+  /srv/ \
+  /srv/


### PR DESCRIPTION
This is maybe the most annoying change -- feel free to close it if you
don't think it is worth it.

With it, the final image is around 35 MB in size, and doesn't contain
gcc, python-dev, etc.